### PR TITLE
Add missing feature checks in type alias definitions

### DIFF
--- a/dual-quaternions/types.lisp
+++ b/dual-quaternions/types.lisp
@@ -32,7 +32,9 @@
 (define-slot-accessor quat2-type q2real 0)
 (define-slot-accessor quat2-type q2dual 1)
 
-(define-type-alias *quat2 quat2 dquat2)
+(define-type-alias *quat2
+  #-3d-math-no-f32 quat2
+  #-3d-math-no-f64 dquat2)
 
 (defmacro define-quat2-constructors (<t>)
   (flet ((constructor (real dual)

--- a/quaternions/types.lisp
+++ b/quaternions/types.lisp
@@ -33,7 +33,9 @@
 (define-slot-accessor quat-type qk 2)
 (define-slot-accessor quat-type qr 3)
 
-(define-type-alias *quat quat dquat)
+(define-type-alias *quat
+  #-3d-math-no-f32 quat
+  #-3d-math-no-f64 dquat)
 
 (defmacro define-quat-constructors (<t>)
   (flet ((constructor (&rest args)

--- a/transforms/types.lisp
+++ b/transforms/types.lisp
@@ -36,7 +36,9 @@
 (define-slot-accessor transform-type tscaling 1)
 (define-slot-accessor transform-type trotation 2)
 
-(define-type-alias *transform transform dtransform)
+(define-type-alias *transform
+  #-3d-math-no-f32 transform
+  #-3d-math-no-f64 dtransform)
 
 (defmacro define-transform-constructors (<t>)
   (flet ((constructor (location scaling rotation)


### PR DESCRIPTION
For quaternions, dual quaternions and transforms.