### PR TITLE
Fix 3d cartesian -> polar converter

### DIFF
--- a/vectors/raw-ops.lisp
+++ b/vectors/raw-ops.lisp
@@ -376,10 +376,10 @@
         ,(case <s>
            (2 `(setf (aref x 0) (,<t> len)
                      (aref x 1) (,<t> atan)))
-           (3 `(let ((d (aref x 2)))
+           (3 `(let ((d (aref a 2)))
                  (setf (aref x 0) (,<t> len)
                        (aref x 1) (,<t> atan)
-                       (aref x 2) (,<t> (/ len d)))))
+                       (aref x 2) (,<t> (acos (/ d len))))))
            (T (template-unfulfillable))))
       x)))
 


### PR DESCRIPTION
Fixes a typo and an error in the calculation. 

```
CL-USER(16): (vcartesian (vpolar (vec -1 -2 -3)))

(VEC3 -0.99999994 -2.0000002 -3.0)
CL-USER(17): (vcartesian (vpolar (vec -1 -22 -3)))

(VEC3 -1.0000007 -22.000002 -2.9999998)
CL-USER(18): (vcartesian (vpolar (vec -11 -22 -3)))

(VEC3 -10.999999 -22.000002 -2.9999993)
CL-USER(19): (vcartesian (vpolar (vec 11 -22 -3)))

(VEC3 10.999999 -22.000002 -2.9999993)
```